### PR TITLE
add hide app option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "okta_app_saml" "saml_app" {
   recipient                = var.recipient
   destination              = var.destination
   audience                 = var.audience
+  hide_web                 = var.hide_web
   subject_name_id_template = "$${user.userName}"
   subject_name_id_format   = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
   response_signed          = true

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,12 @@ variable "audience" {
   description = "Audience URL"
 }
 
+variable "hide_web" {
+  type        = bool
+  default     = false
+  description = "Hide application on Okta Web dashboard"
+}
+
 variable "groups" {
   type = map(object({
     id       = string


### PR DESCRIPTION
Add the option to hide the app from the end user in Okta. Useful for when the application doesn't support IDP initiated flow.